### PR TITLE
Update workflow path and clarify repo root

### DIFF
--- a/.github/workflows/crossposter.yml
+++ b/.github/workflows/crossposter.yml
@@ -18,13 +18,11 @@ jobs:
       - name: List files
         run: ls -R
       - name: Install dependencies
-        run: |
-          cd SocialSync
-          npm install
+        run: npm install
+        working-directory: .
       - name: Run script
-        run: |
-          cd SocialSync
-          node src/index.js
+        run: node src/index.js
+        working-directory: .
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           MASTODON_INSTANCE: ${{ secrets.MASTODON_INSTANCE }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node modules
+node_modules/
+
+# Environment variables
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Operating system files
+.DS_Store
+
+# Production builds
+/dist
+
+# Coverage directory
+/coverage
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "twitter-crossposter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "twitter-crossposter",
+      "version": "1.0.0",
+      "dependencies": {
+        "@google/generative-ai": "^0.1.3",
+        "axios": "^1.6.7",
+        "dotenv": "^16.4.5",
+        "mastodon-api": "^1.3.0",
+        "puppeteer": "^22.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use explicit working directory in the crossposter workflow
- keep `.gitignore` and placeholder `package-lock.json` in repo

## Testing
- `node --version`
- `npm --version`
- `npm install --package-lock-only --prefer-offline --no-audit --no-fund --loglevel error` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687871395b188329b91e868cebb953cd